### PR TITLE
Esconder totales en kendoPivotGrid

### DIFF
--- a/README-hide-totals.md
+++ b/README-hide-totals.md
@@ -1,0 +1,181 @@
+# Cómo Ocultar Totales en KendoPivotGrid
+
+Este documento explica las diferentes formas de ocultar filas, columnas y celdas de totales en un KendoPivotGrid de Kendo UI jQuery.
+
+## Métodos Disponibles
+
+### 1. Configuración en el DataSource (Recomendado)
+
+La forma más eficiente es configurar los totales directamente en el DataSource:
+
+```javascript
+$("#pivotgrid").kendoPivotGrid({
+    dataSource: {
+        // ... otras configuraciones
+        totals: {
+            rows: false,    // Ocultar filas de totales
+            columns: false  // Ocultar columnas de totales
+        }
+    }
+});
+```
+
+**Para alternar dinámicamente:**
+```javascript
+function toggleTotals() {
+    var dataSource = pivotGrid.dataSource;
+    dataSource.options.totals = {
+        rows: !dataSource.options.totals.rows,
+        columns: !dataSource.options.totals.columns
+    };
+    dataSource.read();
+}
+```
+
+### 2. CSS para Ocultar Totales
+
+Puedes usar CSS para ocultar totales específicos:
+
+```css
+/* Ocultar todos los totales */
+.hide-totals .k-pivotgrid-total {
+    display: none !important;
+}
+
+/* Ocultar solo filas de totales */
+.hide-total-rows .k-pivotgrid-total-row {
+    display: none !important;
+}
+
+/* Ocultar solo columnas de totales */
+.hide-total-columns .k-pivotgrid-total-column {
+    display: none !important;
+}
+```
+
+**JavaScript para aplicar las clases:**
+```javascript
+function hideAllTotals() {
+    $("#pivotgrid").addClass("hide-totals");
+}
+
+function hideTotalRows() {
+    $("#pivotgrid").addClass("hide-total-rows");
+}
+
+function hideTotalColumns() {
+    $("#pivotgrid").addClass("hide-total-columns");
+}
+
+function showAllTotals() {
+    $("#pivotgrid").removeClass("hide-totals hide-total-rows hide-total-columns");
+}
+```
+
+### 3. Configuración Inicial sin Totales
+
+Si quieres que el PivotGrid nunca muestre totales, configura así desde el inicio:
+
+```javascript
+$("#pivotgrid").kendoPivotGrid({
+    dataSource: {
+        // ... otras configuraciones
+        totals: {
+            rows: false,
+            columns: false
+        }
+    }
+});
+```
+
+## Ejemplos Prácticos
+
+### Para tu implementación actual (pivot-v3.html)
+
+Basándome en tu archivo `pivot-v3.html`, aquí están las modificaciones que necesitas:
+
+1. **Agregar configuración de totales en el DataSource:**
+```javascript
+dataSource: {
+    // ... configuración existente
+    totals: {
+        rows: false,    // Cambiar a true si quieres mostrar
+        columns: false  // Cambiar a true si quieres mostrar
+    }
+}
+```
+
+2. **Agregar CSS para control dinámico:**
+```css
+.hide-totals .k-pivotgrid-total {
+    display: none !important;
+}
+.hide-total-rows .k-pivotgrid-total-row {
+    display: none !important;
+}
+.hide-total-columns .k-pivotgrid-total-column {
+    display: none !important;
+}
+```
+
+3. **Agregar funciones JavaScript:**
+```javascript
+function hideAllTotals() {
+    $("#pivotgrid").addClass("hide-totals");
+}
+
+function showAllTotals() {
+    $("#pivotgrid").removeClass("hide-totals");
+}
+
+function toggleTotalsDataSource() {
+    var dataSource = pivotGrid.dataSource;
+    var currentTotals = dataSource.options.totals;
+    
+    dataSource.options.totals = {
+        rows: !currentTotals.rows,
+        columns: !currentTotals.columns
+    };
+    
+    dataSource.read();
+}
+```
+
+## Ventajas y Desventajas
+
+### Método 1 (DataSource)
+**Ventajas:**
+- Más eficiente en rendimiento
+- Los datos no se calculan
+- Cambios inmediatos
+
+**Desventajas:**
+- Requiere recargar los datos
+
+### Método 2 (CSS)
+**Ventajas:**
+- Cambios instantáneos
+- No requiere recargar datos
+- Más flexible para estilos
+
+**Desventajas:**
+- Los datos siguen calculándose
+- Puede afectar el rendimiento con grandes datasets
+
+## Recomendaciones
+
+1. **Para ocultar totales permanentemente:** Usa la configuración del DataSource
+2. **Para alternar totales dinámicamente:** Usa CSS para cambios rápidos
+3. **Para control granular:** Combina ambos métodos
+
+## Archivos de Ejemplo
+
+- `pivot-hide-totals.html`: Ejemplo completo con los 3 métodos
+- `pivot-v3-hide-totals.html`: Versión modificada de tu archivo actual
+
+## Notas Importantes
+
+- Los selectores CSS pueden variar según la versión de Kendo UI
+- Siempre prueba en tu entorno específico
+- Considera el impacto en el rendimiento con datasets grandes
+- Los totales se calculan en el servidor, por lo que ocultarlos con CSS no mejora el rendimiento del cálculo

--- a/pivot-hide-totals.html
+++ b/pivot-hide-totals.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Kendo PivotGrid - Ocultar Totales</title>
+    <link href="https://kendo.cdn.telerik.com/2023.3.1010/styles/kendo.default-v2.min.css" rel="stylesheet" />
+    <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
+    <script src="https://kendo.cdn.telerik.com/2023.3.1010/js/kendo.all.min.js"></script>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 2rem;
+        }
+        .demo-section {
+            margin: 20px 0;
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+        }
+        .controls {
+            margin: 10px 0;
+        }
+        button {
+            margin: 5px;
+            padding: 8px 15px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #0056b3;
+        }
+        /* CSS para ocultar totales */
+        .hide-totals .k-pivotgrid-total {
+            display: none !important;
+        }
+        .hide-total-rows .k-pivotgrid-total-row {
+            display: none !important;
+        }
+        .hide-total-columns .k-pivotgrid-total-column {
+            display: none !important;
+        }
+    </style>
+</head>
+<body>
+    <h1>Kendo PivotGrid - Ocultar Totales</h1>
+    
+    <div class="demo-section">
+        <h2>Método 1: Configuración en el DataSource</h2>
+        <div class="controls">
+            <button onclick="toggleTotalsMethod1()">Alternar Totales (Método 1)</button>
+        </div>
+        <div id="pivotgrid1"></div>
+    </div>
+
+    <div class="demo-section">
+        <h2>Método 2: CSS para ocultar totales</h2>
+        <div class="controls">
+            <button onclick="toggleTotalsMethod2()">Alternar Totales (Método 2)</button>
+        </div>
+        <div id="pivotgrid2"></div>
+    </div>
+
+    <div class="demo-section">
+        <h2>Método 3: JavaScript para ocultar totales específicos</h2>
+        <div class="controls">
+            <button onclick="hideTotalRows()">Ocultar Filas de Totales</button>
+            <button onclick="hideTotalColumns()">Ocultar Columnas de Totales</button>
+            <button onclick="showAllTotals()">Mostrar Todos los Totales</button>
+        </div>
+        <div id="pivotgrid3"></div>
+    </div>
+
+    <script>
+        var pivotGrid1, pivotGrid2, pivotGrid3;
+        var showTotals1 = true;
+        var showTotals2 = true;
+
+        // Datos de ejemplo
+        var data = [
+            { product: "A", category: "Electronics", year: "2022", amount: 200 },
+            { product: "B", category: "Electronics", year: "2022", amount: 300 },
+            { product: "C", category: "Furniture", year: "2023", amount: 150 },
+            { product: "D", category: "Furniture", year: "2023", amount: 350 },
+            { product: "E", category: "Electronics", year: "2023", amount: 400 },
+            { product: "F", category: "Furniture", year: "2022", amount: 250 }
+        ];
+
+        $(document).ready(function() {
+            initializePivotGrids();
+        });
+
+        function initializePivotGrids() {
+            // Método 1: Configuración en el DataSource
+            pivotGrid1 = $("#pivotgrid1").kendoPivotGrid({
+                dataSource: {
+                    type: "json",
+                    data: data,
+                    schema: {
+                        cube: {
+                            dimensions: {
+                                product: { caption: "Product", uniqueName: "product" },
+                                category: { caption: "Category", uniqueName: "category" },
+                                year: { caption: "Year", uniqueName: "year" }
+                            },
+                            measures: {
+                                amount: {
+                                    field: "amount",
+                                    aggregate: "sum",
+                                    format: "{0:c}",
+                                    caption: "Total Amount"
+                                }
+                            }
+                        }
+                    },
+                    columns: [{ name: "year" }],
+                    rows: [{ name: "category" }, { name: "product" }],
+                    measures: ["amount"],
+                    // Configuración para ocultar totales
+                    totals: {
+                        rows: false,
+                        columns: false
+                    }
+                },
+                height: 300,
+                columnWidth: 120
+            }).data("kendoPivotGrid");
+
+            // Método 2: CSS para ocultar totales
+            pivotGrid2 = $("#pivotgrid2").kendoPivotGrid({
+                dataSource: {
+                    type: "json",
+                    data: data,
+                    schema: {
+                        cube: {
+                            dimensions: {
+                                product: { caption: "Product", uniqueName: "product" },
+                                category: { caption: "Category", uniqueName: "category" },
+                                year: { caption: "Year", uniqueName: "year" }
+                            },
+                            measures: {
+                                amount: {
+                                    field: "amount",
+                                    aggregate: "sum",
+                                    format: "{0:c}",
+                                    caption: "Total Amount"
+                                }
+                            }
+                        }
+                    },
+                    columns: [{ name: "year" }],
+                    rows: [{ name: "category" }, { name: "product" }],
+                    measures: ["amount"]
+                },
+                height: 300,
+                columnWidth: 120
+            }).data("kendoPivotGrid");
+
+            // Método 3: JavaScript para controlar totales
+            pivotGrid3 = $("#pivotgrid3").kendoPivotGrid({
+                dataSource: {
+                    type: "json",
+                    data: data,
+                    schema: {
+                        cube: {
+                            dimensions: {
+                                product: { caption: "Product", uniqueName: "product" },
+                                category: { caption: "Category", uniqueName: "category" },
+                                year: { caption: "Year", uniqueName: "year" }
+                            },
+                            measures: {
+                                amount: {
+                                    field: "amount",
+                                    aggregate: "sum",
+                                    format: "{0:c}",
+                                    caption: "Total Amount"
+                                }
+                            }
+                        }
+                    },
+                    columns: [{ name: "year" }],
+                    rows: [{ name: "category" }, { name: "product" }],
+                    measures: ["amount"]
+                },
+                height: 300,
+                columnWidth: 120
+            }).data("kendoPivotGrid");
+        }
+
+        // Método 1: Alternar totales usando configuración del DataSource
+        function toggleTotalsMethod1() {
+            showTotals1 = !showTotals1;
+            var dataSource = pivotGrid1.dataSource;
+            
+            dataSource.options.totals = {
+                rows: showTotals1,
+                columns: showTotals1
+            };
+            
+            dataSource.read();
+        }
+
+        // Método 2: Alternar totales usando CSS
+        function toggleTotalsMethod2() {
+            showTotals2 = !showTotals2;
+            var container = $("#pivotgrid2");
+            
+            if (showTotals2) {
+                container.removeClass("hide-totals");
+            } else {
+                container.addClass("hide-totals");
+            }
+        }
+
+        // Método 3: Ocultar filas de totales
+        function hideTotalRows() {
+            var container = $("#pivotgrid3");
+            container.removeClass("hide-total-columns");
+            container.addClass("hide-total-rows");
+        }
+
+        // Método 3: Ocultar columnas de totales
+        function hideTotalColumns() {
+            var container = $("#pivotgrid3");
+            container.removeClass("hide-total-rows");
+            container.addClass("hide-total-columns");
+        }
+
+        // Método 3: Mostrar todos los totales
+        function showAllTotals() {
+            var container = $("#pivotgrid3");
+            container.removeClass("hide-total-rows hide-total-columns");
+        }
+    </script>
+</body>
+</html>

--- a/pivot-v3-hide-totals.html
+++ b/pivot-v3-hide-totals.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<base href="https://demos.telerik.com/kendo-ui/pivotgrid/index" />
+		<style>
+			html {
+				font-size: 14px;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+		</style>
+		<title>PivotGrid con Opciones para Ocultar Totales</title>
+		<link
+			href="https://kendo.cdn.telerik.com/themes/11.0.2/default/default-main.css"
+			rel="stylesheet"
+		/>
+		<script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
+		<script src="https://kendo.cdn.telerik.com/2025.2.702/js/kendo.all.min.js"></script>
+	</head>
+	<body>
+		<hr />
+		<div id="chart"></div>
+		<div id="stockChart"></div>
+		<style>
+			.selected-cell {
+				background-color: rgba(0, 123, 255, 0.2);
+				outline: 2px solid #007bff;
+			}
+			.chart-container {
+				margin: 20px 0;
+				padding: 10px;
+				border: 1px solid #ddd;
+				border-radius: 5px;
+			}
+			.k-pivotgrid-total {
+				background-color: #ffe0ef !important;
+			}
+
+			/* Estilo para celdas de totales */
+			.k-alt {
+				background-color: #ffb347 !important;
+				color: black !important;
+				font-weight: bold !important;
+			}
+
+			/* Estilo para headers de totales */
+			.k-grid-header-table .k-table-tbody tr th.k-alt {
+				background-color: #ffb347 !important;
+				color: black !important;
+				font-weight: bold !important;
+			}
+
+			/* CSS para ocultar totales */
+			.hide-totals .k-pivotgrid-total {
+				display: none !important;
+			}
+			.hide-total-rows .k-pivotgrid-total-row {
+				display: none !important;
+			}
+			.hide-total-columns .k-pivotgrid-total-column {
+				display: none !important;
+			}
+
+			.controls {
+				margin: 10px 0;
+				padding: 10px;
+				background-color: #f8f9fa;
+				border-radius: 5px;
+			}
+			.controls button {
+				margin: 5px;
+				padding: 8px 15px;
+				background-color: #007bff;
+				color: white;
+				border: none;
+				border-radius: 4px;
+				cursor: pointer;
+			}
+			.controls button:hover {
+				background-color: #0056b3;
+			}
+		</style>
+		<div style="margin-bottom: 20px">
+			<button id="refreshPivotData">Refrescar Datos</button>
+		</div>
+
+		<!-- Controles para ocultar totales -->
+		<div class="controls">
+			<h3>Controles para Ocultar Totales:</h3>
+			<button onclick="hideAllTotals()">Ocultar Todos los Totales</button>
+			<button onclick="showAllTotals()">Mostrar Todos los Totales</button>
+			<button onclick="hideTotalRows()">Ocultar Solo Filas de Totales</button>
+			<button onclick="hideTotalColumns()">Ocultar Solo Columnas de Totales</button>
+			<button onclick="toggleTotalsDataSource()">Alternar Totales (DataSource)</button>
+		</div>
+
+		<div id="pivotgrid" style="margin-bottom: 20px"></div>
+		<button id="showChart">Mostrar Chart desde Pivot HTML</button>
+		<button id="showStockChart">Mostrar Stock Chart</button>
+		<script>
+			var pivotGrid;
+			var processedData = {};
+			var sampleData = [];
+			var showTotals = true;
+
+			sampleData = [
+				{
+					PASFundName: "Ardsley - MAP MLH291_00",
+					fundid: 1494,
+					managername: "Ardsley - MAP MLH291_00",
+					securitydescription: "BRISTOL-MYERS SQUIBB CO",
+					assetclass: "Equity",
+					securitytype: "Common Share",
+					gicssector: "Health Care",
+					region: "Unassigned",
+					country: "USA",
+					lhExposure: 207.7516,
+					marketvalue: 207.7516,
+					NetNotional: 207.7516,
+					attributiondate: "2025-03-13T00:00:00",
+					FundIDFK: 1494,
+					Net_lhExposure: 207.7516,
+					Gross_lhExposure: 207.7516,
+					Contribution: 9.242525503308228,
+					Pnl: 100,
+					NMV: 8.880125150779678,
+					GMV: 8.880125150779678,
+				},
+				{
+					PASFundName: "Ardsley - MAP MLH291_00",
+					fundid: 1494,
+					managername: "Ardsley - MAP MLH291_00",
+					securitydescription: "TERADYNE INC",
+					assetclass: "Equity",
+					securitytype: "Common Share 2",
+					gicssector: "Information Technology",
+					region: "Unassigned",
+					country: "USA",
+					lhExposure: 0.0,
+					marketvalue: 0.0,
+					NetNotional: 0.0,
+					attributiondate: "2025-03-14T00:00:00",
+					FundIDFK: 1494,
+					Net_lhExposure: 0.0,
+					Gross_lhExposure: 0.0,
+					Contribution: 5.123456789,
+					Pnl: 50,
+					NMV: 4.567890123,
+					GMV: 4.567890123,
+				},
+				{
+					PASFundName: "Ardsley - MAP MLH291_00",
+					fundid: 1494,
+					managername: "Ardsley - MAP MLH291_00",
+					securitydescription: "APPLE INC",
+					assetclass: "Equity",
+					securitytype: "Common Share",
+					gicssector: "Information Technology",
+					region: "Unassigned",
+					country: "USA",
+					lhExposure: 150.0,
+					marketvalue: 150.0,
+					NetNotional: 150.0,
+					attributiondate: "2025-03-15T00:00:00",
+					FundIDFK: 1494,
+					Net_lhExposure: 150.0,
+					Gross_lhExposure: 150.0,
+					Contribution: 12.345678901,
+					Pnl: 75,
+					NMV: 11.111111111,
+					GMV: 11.111111111,
+				}
+			];
+
+			$(document).ready(function () {
+				initializePivotGrid();
+			});
+
+			function initializePivotGrid() {
+				pivotgrid = $("#pivotgrid")
+					.kendoPivotGrid({
+						dataSource: {
+							data: sampleData,
+							schema: {
+								model: {
+									fields: {
+										PASFundName: { type: "string" },
+										fundid: { type: "number" },
+										managername: { type: "string" },
+										securitydescription: { type: "string" },
+										assetclass: { type: "string" },
+										securitytype: { type: "string" },
+										gicssector: { type: "string" },
+										region: { type: "string" },
+										country: { type: "string" },
+										lhExposure: { type: "number" },
+										marketvalue: { type: "number" },
+										NetNotional: { type: "number" },
+										attributiondate: { type: "string" },
+										FundIDFK: { type: "number" },
+										Net_lhExposure: { type: "number" },
+										Gross_lhExposure: { type: "number" },
+										Contribution: { type: "number" },
+										Pnl: { type: "number" },
+										NMV: { type: "number" },
+										GMV: { type: "number" },
+									},
+								},
+								cube: {
+									dimensions: {
+										PASFundName: { caption: "PASFundName" },
+										fundid: { caption: "fundid" },
+										managername: {
+											caption: "managername",
+										},
+										securitydescription: {
+											caption: "securitydescription",
+										},
+										assetclass: {
+											caption: "assetclass",
+										},
+										securitytype: { caption: "securitytype" },
+										gicssector: {
+											caption: "gicssector",
+										},
+										region: { caption: "region" },
+										country: { caption: "country" },
+										attributiondate: {
+											caption: "attributiondate",
+										},
+										FundIDFK: { caption: "FundIDFK" },
+									},
+									measures: {
+										Contribution: {
+											field: "Contribution",
+											aggregate: "sum",
+											format: "{0:n2}",
+										},
+										Pnl: {
+											field: "Pnl",
+											aggregate: "sum",
+											format: "{0:n2}",
+										},
+										NMV: {
+											field: "NMV",
+											aggregate: "sum",
+											format: "{0:n2}",
+										},
+										GMV: {
+											field: "GMV",
+											aggregate: "sum",
+											format: "{0:n2}",
+										},
+									},
+								},
+							},
+							rows: [
+								{ name: "PASFundName", expand: true },
+								{ name: "securitytype", expand: true },
+							],
+							columns: [{ name: "attributiondate", expand: true }, { name: "country", expand: true }],
+							measures: ["Contribution", "Pnl"],
+							expand: true,
+							// Configuración inicial para mostrar totales
+							totals: {
+								rows: true,
+								columns: true
+							}
+						},
+						height: 400,
+						dataBound: function () {
+							pivotGrid = this;
+							console.log("entra por databound");
+						},
+					})
+					.data("kendoPivotGrid");
+			}
+
+			// Función para ocultar todos los totales usando CSS
+			function hideAllTotals() {
+				var container = $("#pivotgrid");
+				container.removeClass("hide-total-rows hide-total-columns");
+				container.addClass("hide-totals");
+			}
+
+			// Función para mostrar todos los totales
+			function showAllTotals() {
+				var container = $("#pivotgrid");
+				container.removeClass("hide-totals hide-total-rows hide-total-columns");
+			}
+
+			// Función para ocultar solo filas de totales
+			function hideTotalRows() {
+				var container = $("#pivotgrid");
+				container.removeClass("hide-totals hide-total-columns");
+				container.addClass("hide-total-rows");
+			}
+
+			// Función para ocultar solo columnas de totales
+			function hideTotalColumns() {
+				var container = $("#pivotgrid");
+				container.removeClass("hide-totals hide-total-rows");
+				container.addClass("hide-total-columns");
+			}
+
+			// Función para alternar totales usando configuración del DataSource
+			function toggleTotalsDataSource() {
+				showTotals = !showTotals;
+				var dataSource = pivotGrid.dataSource;
+				
+				dataSource.options.totals = {
+					rows: showTotals,
+					columns: showTotals
+				};
+				
+				dataSource.read();
+			}
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
Add options to hide KendoPivotGrid total rows, columns, and cells.

This PR addresses the user's request to hide totals in the KendoPivotGrid by providing three methods: configuring the DataSource, applying CSS classes, and using JavaScript functions to toggle visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea2a2dd6-dcb6-4ffd-b909-f824d0a234e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea2a2dd6-dcb6-4ffd-b909-f824d0a234e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

